### PR TITLE
fix(tui): make Ctrl+Y insert nib's suggested command into the shell

### DIFF
--- a/cmd/tmux.go
+++ b/cmd/tmux.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 // inTmux returns true if running inside tmux
@@ -11,7 +13,13 @@ func IsInTmux() bool {
 	return os.Getenv("TMUX") != "" && os.Getenv("TMUX_PANE") != ""
 }
 
-// runTmuxSplit runs nib in a tmux split pane (like fzf-tmux -d)
+// runTmuxSplit runs nib in a tmux split pane (like fzf-tmux -d).
+//
+// `tmux split-window` returns as soon as the pane is spawned, not when its
+// command exits, so we can't capture the inner nib's selected command from its
+// stdout directly. Instead the inner nib writes its command to a temp file and
+// signals a tmux channel on exit; we block on that channel, then relay the file
+// to our own stdout — which is what the Ctrl+Space shell widget captures.
 func RunTmuxSplit(height string) error {
 	// Get current working directory
 	dir, err := os.Getwd()
@@ -25,29 +33,44 @@ func RunTmuxSplit(height string) error {
 		executable = "nib"
 	}
 
-	// Build the command to run inside the split pane
-	// Use --no-tmux to prevent infinite recursion
-	nibCmd := fmt.Sprintf("%s --height %s --no-tmux", executable, height)
+	// Temp file the inner nib's stdout (the selected command) is captured into,
+	// plus a tmux wait-for channel keyed off its unique name.
+	tmp, err := os.CreateTemp("", "nib-yank-*")
+	if err != nil {
+		return err
+	}
+	outPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(outPath)
+	channel := "nib-" + filepath.Base(outPath)
 
-	// tmux split-window arguments
-	// -d: don't switch focus to new pane initially (we'll switch after)
-	// -v: vertical split (new pane below)
-	// -l: size of the new pane
-	// -c: working directory
-	//
-	// After split, we swap panes so the new pane is below and select it
-	tmuxArgs := []string{
-		"split-window",
-		"-v",         // vertical split (creates pane below)
-		"-l", height, // height of the new pane
-		"-c", dir, // working directory
-		"sh", "-c", nibCmd,
+	// Inside the pane: run nib (with --no-tmux to avoid recursion), redirect its
+	// stdout to the temp file, then signal the channel so we can stop waiting.
+	inner := fmt.Sprintf("%s --height %s --no-tmux > %s; tmux wait-for -S %s",
+		executable, height, shellQuote(outPath), shellQuote(channel))
+
+	// -v vertical split (pane below), -l height, -c working dir. Focus moves to
+	// the new pane so the user interacts with nib.
+	split := exec.Command("tmux", "split-window", "-v", "-l", height, "-c", dir, "sh", "-c", inner)
+	split.Stdin = os.Stdin
+	split.Stderr = os.Stderr
+	if err := split.Run(); err != nil {
+		return err
 	}
 
-	cmd := exec.Command("tmux", tmuxArgs...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// Block until the inner nib exits and signals the channel.
+	_ = exec.Command("tmux", "wait-for", channel).Run()
 
-	return cmd.Run()
+	// Relay the captured command to our stdout for the shell widget to insert.
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil // nothing captured (e.g. user cancelled) — not an error
+	}
+	fmt.Print(string(data))
+	return nil
+}
+
+// shellQuote single-quotes s for safe interpolation into the `sh -c` string.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/theme/copy.go
+++ b/theme/copy.go
@@ -4,7 +4,7 @@ package theme
 const (
 	BrandName = "nib"
 
-	HelpDefault      = "enter send · ctrl+c interrupt · esc exit"
+	HelpDefault      = "enter send · ctrl+y use command · esc exit"
 	HelpApproval     = "y yes · a always · n no · e edit · A all · esc deny"
 	HelpApprovalEdit = "enter submit · esc cancel"
 	ApprovePrompt    = "[y] yes  [a] always  [n] no  [e] edit  [A] all"

--- a/tui/model.go
+++ b/tui/model.go
@@ -376,6 +376,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEsc:
 			return m.quit()
 
+		case tea.KeyCtrlY:
+			// Yank nib's last suggested command to the shell and exit, so the
+			// Ctrl+Space widget inserts it at the prompt. No-op if there's
+			// nothing to yank or a turn is still in flight.
+			if !m.sessionReady || m.loading {
+				return m, nil
+			}
+			cmd := lastSuggestedCommand(m.messages)
+			if cmd == "" {
+				m.status = "no command to use yet"
+				return m, nil
+			}
+			m.output = cmd
+			return m.quit()
+
 		case tea.KeyCtrlB:
 			// Background the running foreground work: a sub-agent first,
 			// otherwise a running foreground shell command.
@@ -585,7 +600,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.awaitingApproval = true
 		m.approvalEditing = false // every approval starts in key-driven choice mode
 		m.loading = false         // Allow user input for approval
-		m.textarea.Focus() // Ensure textarea is focused for input
+		m.textarea.Focus()        // Ensure textarea is focused for input
 		m.updateViewport()
 		// Continue listening for more tool requests
 		cmds = append(cmds, m.listenToolRequest())

--- a/tui/yank.go
+++ b/tui/yank.go
@@ -1,0 +1,65 @@
+package tui
+
+import "strings"
+
+// lastSuggestedCommand returns the command nib most recently suggested, suitable
+// for inserting at the user's shell prompt (the Ctrl+Y "yank" flow).
+//
+// It looks at the last assistant message and returns the content of its last
+// fenced ``` code block. If the message has no code block but is a single line,
+// that line is returned verbatim. Otherwise it returns "" (nothing to yank).
+func lastSuggestedCommand(messages []ChatMessage) string {
+	var content string
+	found := false
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "assistant" {
+			content = messages[i].Content
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ""
+	}
+
+	if block := lastFencedBlock(content); block != "" {
+		return block
+	}
+
+	// No code block: accept a single-line answer, unwrapping any surrounding
+	// inline-code backticks (models often reply with `the command`). Never
+	// yank multi-line prose.
+	trimmed := strings.TrimSpace(content)
+	if trimmed != "" && !strings.Contains(trimmed, "\n") {
+		return strings.TrimSpace(strings.Trim(trimmed, "`"))
+	}
+	return ""
+}
+
+// lastFencedBlock returns the content of the last complete ```-fenced block in
+// s, trimmed of surrounding whitespace. Returns "" if there is no closed block.
+func lastFencedBlock(s string) string {
+	lines := strings.Split(s, "\n")
+	var last string
+	var cur []string
+	inBlock := false
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			if inBlock {
+				// Closing fence: this block is complete.
+				last = strings.TrimSpace(strings.Join(cur, "\n"))
+				cur = nil
+				inBlock = false
+			} else {
+				// Opening fence (any language tag after ``` is ignored).
+				inBlock = true
+				cur = nil
+			}
+			continue
+		}
+		if inBlock {
+			cur = append(cur, line)
+		}
+	}
+	return last
+}

--- a/tui/yank_test.go
+++ b/tui/yank_test.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestLastSuggestedCommand(t *testing.T) {
+	cases := []struct {
+		name     string
+		messages []ChatMessage
+		want     string
+	}{
+		{
+			name:     "no messages",
+			messages: nil,
+			want:     "",
+		},
+		{
+			name: "fenced block with language tag",
+			messages: []ChatMessage{
+				{Role: "user", Content: "find big files"},
+				{Role: "assistant", Content: "Here you go:\n\n```bash\nfind . -type f -size +100M\n```\n"},
+			},
+			want: "find . -type f -size +100M",
+		},
+		{
+			name: "fenced block without language tag",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "```\nls -la\n```"},
+			},
+			want: "ls -la",
+		},
+		{
+			name: "multiple blocks returns the last",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "first:\n```\nls\n```\nor better:\n```\nls -la\n```"},
+			},
+			want: "ls -la",
+		},
+		{
+			name: "uses the last assistant message",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "```\necho one\n```"},
+				{Role: "user", Content: "no, the other one"},
+				{Role: "assistant", Content: "```\necho two\n```"},
+			},
+			want: "echo two",
+		},
+		{
+			name: "ignores tool and agent messages after the assistant",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "```\nuname -a\n```"},
+				{Role: "tool", Name: "bash", Content: "Linux ..."},
+			},
+			want: "uname -a",
+		},
+		{
+			name: "no fence, single-line answer is used verbatim",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "  git status --short  "},
+			},
+			want: "git status --short",
+		},
+		{
+			name: "single line wrapped in inline backticks is unwrapped",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "`ls -la`"},
+			},
+			want: "ls -la",
+		},
+		{
+			name: "no fence, multi-line prose yields nothing",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "You can do this in a few ways.\nFirst, try one thing.\nThen another."},
+			},
+			want: "",
+		},
+		{
+			name: "multi-line fenced block is preserved",
+			messages: []ChatMessage{
+				{Role: "assistant", Content: "```bash\nset -e\nls -la\n```"},
+			},
+			want: "set -e\nls -la",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lastSuggestedCommand(tc.messages); got != tc.want {
+				t.Fatalf("lastSuggestedCommand() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCtrlYYanksCommand verifies Ctrl+Y on an idle session sets the model's
+// Output() to the last suggested command and quits, so the shell widget can
+// insert it at the prompt.
+func TestCtrlYYanksCommand(t *testing.T) {
+	m := Model{
+		sessionReady: true,
+		cancel:       func() {},
+		messages: []ChatMessage{
+			{Role: "assistant", Content: "```\nfind . -type f -size +100M\n```"},
+		},
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlY})
+	mn := next.(Model)
+	if !mn.quitting {
+		t.Fatal("Ctrl+Y should quit so the shell can insert the command")
+	}
+	if got := mn.Output(); got != "find . -type f -size +100M" {
+		t.Fatalf("Output() = %q, want the suggested command", got)
+	}
+}
+
+// TestCtrlYNoCommandStaysOpen verifies Ctrl+Y is a no-op (no quit, no output)
+// when there is no command to yank.
+func TestCtrlYNoCommandStaysOpen(t *testing.T) {
+	m := Model{
+		sessionReady: true,
+		cancel:       func() {},
+		messages: []ChatMessage{
+			{Role: "assistant", Content: "I can't help with that right now.\nTry rephrasing your request."},
+		},
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlY})
+	mn := next.(Model)
+	if mn.quitting {
+		t.Fatal("Ctrl+Y with no command should not quit")
+	}
+	if mn.Output() != "" {
+		t.Fatalf("Output() = %q, want empty", mn.Output())
+	}
+}


### PR DESCRIPTION
The Ctrl+Space widget captures nib's stdout to insert a command at the prompt, but the TUI never set the output: the model's `output` field was declared and returned by Output() yet assigned nowhere, so Output() was always empty.

- Add Ctrl+Y ('yank'): pull the last suggested command from nib's latest answer (last fenced code block; else a single-line answer, unwrapping inline backticks) into output and exit. No-op when there's nothing to yank.
- Fix the tmux path: `tmux split-window` returns before the inner nib exits, so its stdout never reached the widget. RunTmuxSplit now captures the inner nib's output via a temp file + `tmux wait-for` channel and relays it to stdout.
- Advertise the key in the input footer.
- Unit tests for command extraction and the Ctrl+Y handler.