### PR TITLE
feat(chat): OnStepContent callback — surface the model's between-tool…

### DIFF
--- a/chat/callbacks.go
+++ b/chat/callbacks.go
@@ -104,7 +104,13 @@ type Callbacks struct {
 	// fire afterwards. Optional — leave nil for the non-streaming path.
 	OnStream   func(ev StreamEvent)
 	OnToolCall func(req ToolCallRequest) ToolCallResponse
-	OnResponse  func(response string)
+	// OnStepContent is called with the assistant text that accompanied a tool
+	// selection ("I'll search for X now…") at the step boundary, before the
+	// selected tools run — so a UI can commit the commentary in chronological
+	// order relative to OnToolResult. Never fires with empty content and never
+	// for the turn's final reply (that arrives via OnResponse). Optional.
+	OnStepContent func(content string)
+	OnResponse    func(response string)
 	OnError     func(err error)
 	// OnToolResult is called after a tool finishes, with its output. Optional.
 	OnToolResult func(res ToolResult)

--- a/chat/session.go
+++ b/chat/session.go
@@ -840,6 +840,15 @@ func (s *Session) SendMessage(text string, parts ...ContentPart) (string, error)
 		}),
 	}
 
+	// Step-boundary commentary: the assistant text that accompanied a tool
+	// selection ("I'll search for X now…"), delivered before the tools run so
+	// a UI can commit it in chronological order relative to OnToolResult.
+	if s.callbacks.OnStepContent != nil {
+		cogitoOpts = append(cogitoOpts, cogito.WithStepContentCallback(func(content string) {
+			s.callbacks.OnStepContent(content)
+		}))
+	}
+
 	// Live token streaming: opt into cogito's streaming decision/answer path only
 	// when a consumer wants per-token deltas. Left unset (e.g. the CLI), the path
 	// is identical to before. The step-boundary callbacks still fire either way.

--- a/chat/session_stepcontent_test.go
+++ b/chat/session_stepcontent_test.go
@@ -1,0 +1,127 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mudler/nib/types"
+	"github.com/mudler/xlog"
+)
+
+// TestStepContentReachesCallbackBeforeToolResult verifies the OnStepContent
+// wiring: the assistant commentary that accompanies a tool call ("Let me
+// confirm something first.") must reach OnStepContent at the step boundary,
+// BEFORE that step's OnToolResult — so a UI can commit the commentary in
+// chronological order (text → tool result → final answer) instead of losing
+// it. Before cogito's WithStepContentCallback, this text was dropped outright.
+func TestStepContentReachesCallbackBeforeToolResult(t *testing.T) {
+	xlog.SetLogger(xlog.NewLogger(xlog.LogLevel("error"), ""))
+
+	const stepText = "Let me confirm something first."
+
+	var reqN int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		msg := map[string]any{"role": "assistant"}
+		finish := "stop"
+		if atomic.AddInt64(&reqN, 1) == 1 {
+			// Step 1: commentary alongside an ask_user tool call.
+			msg["content"] = stepText
+			msg["tool_calls"] = []any{map[string]any{
+				"id": "call_ask", "type": "function", "index": 0,
+				"function": map[string]any{"name": "ask_user", "arguments": `{"question":"proceed?"}`},
+			}}
+			finish = "tool_calls"
+		} else {
+			// Step 2: text reply ends the turn.
+			msg["content"] = "done"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "fake", "object": "chat.completion", "model": "fake",
+			"choices": []any{map[string]any{"index": 0, "message": msg, "finish_reason": finish}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := types.Config{
+		Model:        "fake-model",
+		APIKey:       "fake-key",
+		BaseURL:      srv.URL + "/v1",
+		ApprovalMode: "auto",
+		AgentOptions: types.AgentOptions{
+			Iterations:  10,
+			MaxAttempts: 3,
+			MaxRetries:  3,
+		},
+	}
+
+	// events records the cross-callback order the UI would see.
+	var mu chanlessMutexSlice
+	session, err := NewSession(context.Background(), cfg, Callbacks{
+		OnStepContent: func(content string) { mu.append("step:" + content) },
+		OnToolResult:  func(res ToolResult) { mu.append("toolresult:" + res.Name) },
+		OnAskUser:     func(req AskRequest) string { return "yes" },
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer session.Close()
+
+	type sendResult struct {
+		response string
+		err      error
+	}
+	doneCh := make(chan sendResult, 1)
+	go func() {
+		resp, err := session.SendMessage("start")
+		doneCh <- sendResult{resp, err}
+	}()
+
+	select {
+	case res := <-doneCh:
+		if res.err != nil {
+			t.Fatalf("SendMessage: %v", res.err)
+		}
+		if res.response != "done" {
+			t.Fatalf("final response = %q, want %q", res.response, "done")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("run did not finish")
+	}
+
+	want := []string{"step:" + stepText, "toolresult:ask_user"}
+	got := mu.snapshot()
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("events[%d] = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// chanlessMutexSlice is a tiny thread-safe append-only string slice: callbacks
+// fire on the agent goroutine while the test asserts on its own.
+type chanlessMutexSlice struct {
+	mu sync.Mutex
+	s  []string
+}
+
+func (c *chanlessMutexSlice) append(v string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.s = append(c.s, v)
+}
+
+func (c *chanlessMutexSlice) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.s...)
+}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -250,6 +250,15 @@ func RunCLI(ctx context.Context, cfg types.Config, shellJobs *wizmcp.ShellJobs, 
 			fmt.Println(response)
 			fmt.Println()
 		},
+		// The model's step commentary ("I'll search for X now…") — printed dim,
+		// before the tool it announced runs, so the transcript reads in order.
+		OnStepContent: func(content string) {
+			spin.stop()
+			for _, line := range strings.Split(strings.TrimRight(content, "\n"), "\n") {
+				fmt.Println("  " + theme.Subtle.Render(line))
+			}
+			spin.start(theme.Status(theme.VerbWorking, 0))
+		},
 		OnCompactDone: func(before, after int) {
 			fmt.Println(theme.Subtle.Render(compactNotice(before, after)))
 		},

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/jsonschema-go v0.3.0
 	github.com/klippa-app/go-pdfium v1.12.2
 	github.com/modelcontextprotocol/go-sdk v1.0.0
-	github.com/mudler/cogito v0.11.1-0.20260712224535-dd07cc7f0953
+	github.com/mudler/cogito v0.11.1-0.20260716224639-3c908637a657
 	github.com/mudler/xlog v0.0.1
 	github.com/sashabaranov/go-openai v1.41.2
 	golang.org/x/net v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/modelcontextprotocol/go-sdk v1.0.0 h1:Z4MSjLi38bTgLrd/LjSmofqRqyBiVKR
 github.com/modelcontextprotocol/go-sdk v1.0.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mudler/cogito v0.11.1-0.20260712224535-dd07cc7f0953 h1:mITTtn48NMg9bmq7zremy6PCz35hC7xCKVNURwjQQFo=
-github.com/mudler/cogito v0.11.1-0.20260712224535-dd07cc7f0953/go.mod h1:6sfja3lcu2nWRzEc0wwqGNu/eCG3EWgij+8s7xyUeQ4=
+github.com/mudler/cogito v0.11.1-0.20260716224639-3c908637a657 h1:p9hB6s8BhAq3I7m12AWUdZy50mDFRF/7TNvTbMaSVZg=
+github.com/mudler/cogito v0.11.1-0.20260716224639-3c908637a657/go.mod h1:6sfja3lcu2nWRzEc0wwqGNu/eCG3EWgij+8s7xyUeQ4=
 github.com/mudler/xlog v0.0.1 h1:yR3/wszd3ZM6u1n96YITJZ4yUcDgqHSwvQmzUJa+8vg=
 github.com/mudler/xlog v0.0.1/go.mod h1:39f5vcd05Qd6GWKM8IjyHNQ7AmOx3ZM0YfhfIGhC18U=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=


### PR DESCRIPTION
…s commentary in order

Bump cogito to 3c90863, which stops leaking raw tool results (and other model content) through the status callback — the leak that made chat UIs render every tool result twice, once as an unbounded unstyled "status" — and adds WithStepContentCallback for the assistant text that accompanies a tool selection ("I'll search for X now…"), previously dropped outright.

- chat: new optional Callbacks.OnStepContent, wired to cogito's WithStepContentCallback; fires at the step boundary before the selected tools run, so consumers can commit the commentary chronologically relative to OnToolResult (text → tool result → … → final answer).
- cli: print step commentary dim, in-place, before the tool it announced.
- test: TestStepContentReachesCallbackBeforeToolResult drives a fake OpenAI server through a commentary+ask_user step and asserts the cross-callback order.